### PR TITLE
Orfox: Version bump for android app from 38.0 to 38.5.0

### DIFF
--- a/mobile/android/confvars.sh
+++ b/mobile/android/confvars.sh
@@ -5,7 +5,7 @@
 MOZ_APP_BASENAME=Fennec
 MOZ_APP_VENDOR=Mozilla
 
-MOZ_APP_VERSION=38.0
+MOZ_APP_VERSION=38.5.0
 MOZ_APP_UA_NAME=Firefox
 
 MOZ_BRANDING_DIRECTORY=mobile/android/branding/unofficial


### PR DESCRIPTION
Versioning bump, ESR doesn't support fennec and hence this change wasn't made in the base branch.
